### PR TITLE
Security: Unsafe Deserialization via Pickle in AgentState.load()

### DIFF
--- a/effgen/core/state.py
+++ b/effgen/core/state.py
@@ -5,7 +5,6 @@ Agent state management for effGen framework.
 from __future__ import annotations
 
 import json
-import pickle
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any
@@ -56,9 +55,6 @@ class AgentState:
         if format == "json":
             with open(filepath, "w") as f:
                 json.dump(self.to_dict(), f, indent=2, default=str)
-        elif format == "pickle":
-            with open(filepath, "wb") as f:
-                pickle.dump(self, f)
         else:
             raise ValueError(f"Unsupported format: {format}")
 
@@ -78,9 +74,6 @@ class AgentState:
             from ._compat import load_from_dict
 
             return load_from_dict(cls, data, label="AgentState")
-        elif format == "pickle":
-            with open(filepath, "rb") as f:
-                return pickle.load(f)
         else:
             raise ValueError(f"Unsupported format: {format}")
 


### PR DESCRIPTION
## Summary

Security: Unsafe Deserialization via Pickle in AgentState.load()

## Problem

**Severity**: `Critical` | **File**: `effgen/core/state.py:L75`

The `AgentState.load()` method in `effgen/core/state.py` supports loading from pickle format (line 75-76). Pickle deserialization is inherently unsafe as it can execute arbitrary code during unpickling. An attacker who can control the file being loaded could achieve remote code execution. This is particularly dangerous since AgentState is a core component that likely processes user-provided or externally sourced state files.

## Solution

Remove pickle support entirely, or if backward compatibility is required, implement a safe serialization format (like JSON with schema validation) as the default and only format. If pickle must be supported, add extensive warnings in documentation and require explicit opt-in with a security acknowledgment. Consider using safer alternatives like `marshal` with restricted types or implementing a custom restricted unpickler.

## Changes

- `effgen/core/state.py` (modified)