### PR TITLE
Fix MLX engine for current mlx_lm (native tool calling) + Gemma 4 support

### DIFF
--- a/effgen/core/agent_runtime.py
+++ b/effgen/core/agent_runtime.py
@@ -170,6 +170,15 @@ _TOOLCALL_TAG_RE = re.compile(
     r"|<\|[^>|]*\|>",
     re.IGNORECASE,
 )
+# Gemma 4 emits reasoning inside <|channel>...<channel|> (asymmetric delimiters,
+# unlike the <|...|> tags above) and puts the user-facing answer *after* the
+# closing tag. These strip the reasoning so it never surfaces as the answer.
+_GEMMA_CHANNEL_CLOSE_RE = re.compile(r"<channel\|>")
+_GEMMA_DANGLING_CHANNEL_RE = re.compile(r"<\|channel>.*$", re.DOTALL)
+_GEMMA_TOOLCALL_RE = re.compile(r"<\|tool_call>.*?(?:<tool_call\|>|$)", re.DOTALL)
+_GEMMA_STRAY_TOKEN_RE = re.compile(
+    r"<\|?(?:channel|turn|think|tool|tool_call|tool_response|image|audio|video)\|?>"
+)
 
 
 def sanitize_final_answer(text: str | None) -> str | None:
@@ -194,6 +203,17 @@ def sanitize_final_answer(text: str | None) -> str | None:
     # 2b. Remove leaked model tool-call syntax (whole constructs, then stray tags).
     s = _TOOLCALL_CONSTRUCT_RE.sub("", s)
     s = _TOOLCALL_TAG_RE.sub("", s)
+    # 2c. Gemma 4 channel format: reasoning is wrapped in <|channel>...<channel|>
+    #     with the answer after the close tag. Keep only the tail after the last
+    #     close, drop any unclosed (truncated) trailing channel, then clear stray
+    #     channel/tool special tokens. Only fires when the markers are present.
+    if "<|channel>" in s or "<channel|>" in s or "<|tool_call>" in s:
+        closes = list(_GEMMA_CHANNEL_CLOSE_RE.finditer(s))
+        if closes:
+            s = s[closes[-1].end():]
+        s = _GEMMA_DANGLING_CHANNEL_RE.sub("", s)
+        s = _GEMMA_TOOLCALL_RE.sub("", s)
+        s = _GEMMA_STRAY_TOKEN_RE.sub("", s)
     # 3. Drop trailing Observation/Thought/Question/Action bleed.
     s = _TRAILING_BLEED_RE.sub("", s)
     # 4. If a line-anchored answer label is present, the real answer is what

--- a/effgen/core/tool_calling.py
+++ b/effgen/core/tool_calling.py
@@ -399,6 +399,16 @@ class NativeFunctionCallingStrategy(ToolCallingStrategy):
         if not text or not isinstance(text, str):
             return result
 
+        # --- Try Gemma 4 channel format (asymmetric delimiters) ---
+        # Gemma 4 wraps reasoning in <|channel>...<channel|> and tool calls in
+        # <|tool_call>call:NAME{...}<tool_call|>. These markers are unknown to
+        # the other parsers below, so without this branch the whole reasoning
+        # trace leaks into the "final answer" and tool calls never fire.
+        if "<|channel>" in text or "<|tool_call>" in text or "<channel|>" in text:
+            gemma = self._parse_gemma_channels(text, tools)
+            if gemma is not None:
+                return gemma
+
         # --- Try Qwen format: <tool_call>...</tool_call> ---
         qwen_match = re.search(
             r'<tool_call>\s*(\{.*?\})\s*</tool_call>',
@@ -490,10 +500,104 @@ class NativeFunctionCallingStrategy(ToolCallingStrategy):
         if text_stripped and not any(marker in text for marker in [
             "<tool_call>", "<|python_tag|>", "<function=", "[TOOL_CALLS]",
             "Thought:", "Action:", "Tool:", '"name"', '"function"',
+            "<|channel>", "<channel|>", "<|tool_call>",
         ]):
             result.final_answer = text_stripped
             logger.debug("No tool call markers found, treating as final answer")
 
+        return result
+
+    # -- Gemma 4 channel/tool_call parsing ---------------------------------
+    # Delimiters are asymmetric: open <|x> / close <x|>. Confirmed against the
+    # gemma-4-*-it tokenizer special tokens (<|channel>/<channel|>,
+    # <|tool_call>/<tool_call|>).
+    _GEMMA_STRIP_RE = re.compile(
+        r"<\|?(?:channel|turn|think|tool|tool_call|tool_response|image|audio|video)\|?>"
+    )
+
+    @staticmethod
+    def _loose_json(s: str) -> dict[str, Any]:
+        """Parse Gemma's loose arg blob, e.g. {query: "x"} (unquoted keys)."""
+        s = (s or "").strip()
+        if not s:
+            return {}
+        try:
+            v = json.loads(s)
+            return v if isinstance(v, dict) else {"__raw_input__": s}
+        except (json.JSONDecodeError, TypeError):
+            pass
+        # Quote bare identifier keys: {query: "x"} -> {"query": "x"}
+        fixed = re.sub(r'([{,]\s*)([A-Za-z_]\w*)(\s*:)', r'\1"\2"\3', s)
+        try:
+            v = json.loads(fixed)
+            return v if isinstance(v, dict) else {"__raw_input__": s}
+        except (json.JSONDecodeError, TypeError):
+            return {"__raw_input__": s}
+
+    @staticmethod
+    def _resolve_tool_name(name: str, tools: dict[str, Any] | None) -> str:
+        """Map a slightly-off name (e.g. search_arxiv) onto a real tool.
+
+        Gemma often invents a verb-prefixed name when it isn't handed the tool
+        schema. Fall back to the raw name when nothing plausible matches so the
+        caller still surfaces a clear "tool not found".
+        """
+        if not tools or name in tools:
+            return name
+        lowered = {t.lower(): t for t in tools}
+        if name.lower() in lowered:
+            return lowered[name.lower()]
+        for prefix in ("search_", "get_", "call_", "use_", "run_", "fetch_", "query_"):
+            if name.lower().startswith(prefix):
+                stem = name.lower()[len(prefix):]
+                if stem in lowered:
+                    return lowered[stem]
+        import difflib
+        close = difflib.get_close_matches(name.lower(), list(lowered), n=1, cutoff=0.7)
+        return lowered[close[0]] if close else name
+
+    def _parse_gemma_channels(
+        self, text: str, tools: dict[str, Any] | None
+    ) -> ToolCallResult | None:
+        """Parse Gemma 4 output: strip the reasoning channel, extract tool calls."""
+        result = ToolCallResult(raw_text=text)
+
+        # Reasoning lives in <|channel>[thought]...<channel|>; keep it as thought.
+        thought_match = re.search(
+            r"<\|channel>\s*(?:thought)?\s*(.*?)<channel\|>", text, re.DOTALL
+        )
+        if thought_match:
+            result.thought = thought_match.group(1).strip() or None
+
+        # Tool call: <|tool_call> call:NAME{...} <tool_call|> (close tag optional
+        # when generation is truncated).
+        call_match = re.search(
+            r"<\|tool_call>\s*(?:call:)?\s*([A-Za-z_]\w*)\s*(\{.*?\})"
+            r"\s*(?:<tool_call\|>|$)",
+            text,
+            re.DOTALL,
+        )
+        if call_match:
+            tool_name = self._resolve_tool_name(call_match.group(1).strip(), tools)
+            result.tool_name = tool_name
+            result.arguments = self._loose_json(call_match.group(2))
+            result.is_tool_call = True
+            logger.debug(f"Parsed Gemma-style tool call: {tool_name}")
+            return result
+
+        # No tool call — strip every channel block, leaving the clean answer.
+        cleaned = re.sub(r"<\|channel>.*?<channel\|>", "", text, flags=re.DOTALL)
+        # Drop any unclosed trailing channel (reasoning truncated at max_tokens)
+        # so half-finished thoughts never surface as the answer.
+        cleaned = re.sub(r"<\|channel>.*$", "", cleaned, flags=re.DOTALL)
+        cleaned = self._GEMMA_STRIP_RE.sub("", cleaned).strip()
+        if cleaned:
+            result.final_answer = cleaned
+            logger.debug("Gemma channel format: extracted final answer")
+            return result
+
+        # Only an unclosed/empty reasoning channel (e.g. truncated at max_tokens).
+        # Return an empty result so raw special tokens never leak as the answer.
         return result
 
     def format_tools_for_prompt(self, tools: list) -> list[dict[str, Any]]:

--- a/effgen/models/mlx_engine.py
+++ b/effgen/models/mlx_engine.py
@@ -29,6 +29,55 @@ from effgen.models.base import (
 logger = logging.getLogger(__name__)
 
 
+def _build_mlx_gen_kwargs(config: GenerationConfig, greedy: bool) -> dict[str, Any]:
+    """Build sampling kwargs for mlx_lm ``generate``/``stream_generate``.
+
+    mlx-lm dropped the flat ``temp``/``top_p``/``repetition_penalty`` kwargs
+    (accepted by ``generate_step`` in <=0.19) in favour of a ``sampler`` callable
+    (``make_sampler``) plus ``logits_processors`` (``make_logits_processors``).
+    We build the modern form when those helpers are importable and fall back to
+    the legacy flat kwargs otherwise, so effGen works across mlx-lm versions.
+
+    ``seed`` is applied via ``mx.random.seed`` (stable across versions) rather
+    than passed through, since the newer API no longer accepts a ``seed`` kwarg.
+    """
+    temp = 0.0 if greedy else (config.temperature or 0.0)
+    top_p = 1.0 if greedy else (config.top_p if config.top_p is not None else 1.0)
+    rep_penalty = config.repetition_penalty
+
+    if config.seed is not None:
+        try:  # deterministic sampling; harmless if unsupported
+            import mlx.core as mx
+
+            mx.random.seed(config.seed)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    kwargs: dict[str, Any] = {"max_tokens": config.max_tokens or 512}
+
+    try:
+        from mlx_lm.sample_utils import make_sampler
+    except Exception:  # pragma: no cover - very old mlx-lm: legacy flat kwargs
+        kwargs.update({"temp": temp, "top_p": top_p})
+        if rep_penalty is not None:
+            kwargs["repetition_penalty"] = rep_penalty
+        if config.seed is not None:
+            kwargs["seed"] = config.seed
+        return kwargs
+
+    kwargs["sampler"] = make_sampler(temp=temp, top_p=top_p)
+    if rep_penalty is not None and rep_penalty != 1.0:
+        try:
+            from mlx_lm.sample_utils import make_logits_processors
+
+            kwargs["logits_processors"] = make_logits_processors(
+                repetition_penalty=rep_penalty
+            )
+        except Exception:  # pragma: no cover - processor helper unavailable
+            pass
+    return kwargs
+
+
 class MLXEngine(BatchModel):
     """
     MLX-based model engine for Apple Silicon inference.
@@ -206,6 +255,7 @@ class MLXEngine(BatchModel):
         self,
         prompt: str,
         system_prompt: str | None = None,
+        tools: Any = None,
     ) -> str:
         """
         Format a prompt using the model's chat template.
@@ -253,11 +303,32 @@ class MLXEngine(BatchModel):
                 messages.append({"role": "system", "content": effective_system_prompt})
             messages.append({"role": "user", "content": prompt})
 
-            formatted = self.tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-            )
+            template_kwargs: dict[str, Any] = {
+                "tokenize": False,
+                "add_generation_prompt": True,
+            }
+            # Inject native tool schemas so instruct models (Qwen, Gemma, …) emit
+            # their trained tool-call tokens. Without this the model never learns
+            # the tools exist and just answers in prose — the reason a "calculator
+            # agent" would silently do (sometimes wrong) mental math instead.
+            if tools:
+                template_kwargs["tools"] = tools
+            try:
+                formatted = self.tokenizer.apply_chat_template(
+                    messages, **template_kwargs
+                )
+            except TypeError as e:
+                # Older/simple templates don't accept a tools= kwarg — fall back.
+                if tools:
+                    logger.debug(
+                        f"Chat template does not accept tools param: {e}; "
+                        "falling back to plain template"
+                    )
+                    formatted = self.tokenizer.apply_chat_template(
+                        messages, tokenize=False, add_generation_prompt=True,
+                    )
+                else:
+                    raise
             logger.debug(
                 f"Applied chat template (length: {len(prompt)} -> {len(formatted)})"
             )
@@ -298,10 +369,14 @@ class MLXEngine(BatchModel):
         if config is None:
             config = GenerationConfig()
 
+        # Native tool schemas are passed to the chat template, not to mlx-lm's
+        # generate(), so pull them out of kwargs before building sampling args.
+        tools = kwargs.get("tools")
+
         # Apply chat template
         if not skip_chat_template:
             formatted_prompt = self._format_prompt_with_chat_template(
-                prompt, system_prompt
+                prompt, system_prompt, tools=tools
             )
         else:
             formatted_prompt = prompt
@@ -312,14 +387,7 @@ class MLXEngine(BatchModel):
             # Build MLX generation kwargs. Normalize deterministic generation:
             # temperature<=0 means greedy (temp=0 in mlx-lm); clamp negatives.
             _greedy = config.temperature is None or config.temperature <= 0
-            gen_kwargs: dict[str, Any] = {
-                "max_tokens": config.max_tokens or 512,
-                "temp": 0.0 if _greedy else config.temperature,
-                "top_p": 1.0 if _greedy else config.top_p,
-                "repetition_penalty": config.repetition_penalty,
-            }
-            if config.seed is not None:
-                gen_kwargs["seed"] = config.seed
+            gen_kwargs = _build_mlx_gen_kwargs(config, _greedy)
 
             generated_text = mlx_generate(
                 self.model,
@@ -393,10 +461,13 @@ class MLXEngine(BatchModel):
         if config is None:
             config = GenerationConfig()
 
+        # Native tool schemas go to the chat template, not mlx-lm generate().
+        tools = kwargs.get("tools")
+
         # Apply chat template
         if not skip_chat_template:
             formatted_prompt = self._format_prompt_with_chat_template(
-                prompt, system_prompt
+                prompt, system_prompt, tools=tools
             )
         else:
             formatted_prompt = prompt
@@ -406,14 +477,7 @@ class MLXEngine(BatchModel):
         try:
             # Normalize deterministic generation: temperature<=0 means greedy.
             _greedy = config.temperature is None or config.temperature <= 0
-            gen_kwargs: dict[str, Any] = {
-                "max_tokens": config.max_tokens or 512,
-                "temp": 0.0 if _greedy else config.temperature,
-                "top_p": 1.0 if _greedy else config.top_p,
-                "repetition_penalty": config.repetition_penalty,
-            }
-            if config.seed is not None:
-                gen_kwargs["seed"] = config.seed
+            gen_kwargs = _build_mlx_gen_kwargs(config, _greedy)
 
             for response in stream_generate(
                 self.model,

--- a/tests/unit/test_answer_sanitization.py
+++ b/tests/unit/test_answer_sanitization.py
@@ -94,6 +94,37 @@ def test_strips_tool_call_syntax(leaked, expected):
     assert sanitize(leaked) == expected
 
 
+# --- Gemma 4 channel format (asymmetric <|channel> / <channel|>) --------------
+
+@pytest.mark.parametrize(
+    "leaked, expected",
+    [
+        # The answer follows the closed reasoning channel — keep only the answer.
+        (
+            "<|channel>thought\nlong english planning...\n<channel|>Paris is the capital.",
+            "Paris is the capital.",
+        ),
+        # Japanese answer after the reasoning channel (captured from gemma-4-e4b).
+        (
+            "<|channel>thought\nreasoning\n<channel|>富士山の標高は3,776メートルです。",
+            "富士山の標高は3,776メートルです。",
+        ),
+        # A leaked Gemma tool call in an answer must be removed whole.
+        ('answer <|tool_call>call:arxiv{query: "x"}<tool_call|>', "answer"),
+        # Truncated mid-reasoning (no close tag) must not surface as the answer.
+        ("<|channel>thought\ncut off before finishing", ""),
+    ],
+)
+def test_strips_gemma_channel_format(leaked, expected):
+    assert sanitize(leaked) == expected
+
+
+def test_gemma_sanitize_is_idempotent():
+    raw = "<|channel>thought\nplan\n<channel|>富士山は約3,776mです。"
+    once = sanitize(raw)
+    assert sanitize(once) == once
+
+
 # --- Idempotency --------------------------------------------------------------
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_mlx_engine.py
+++ b/tests/unit/test_mlx_engine.py
@@ -328,3 +328,34 @@ class TestMLXEngineMisc:
         r = repr(engine)
         assert "MLXEngine" in r
         assert "mlx-community/test-model-4bit" in r
+
+
+class TestMLXEngineNativeTools:
+    """The chat template must receive tool schemas so instruct models emit
+    their native tool-call tokens instead of answering in prose."""
+
+    def test_tools_forwarded_to_chat_template(self, loaded_engine):
+        tools = [{"type": "function", "function": {"name": "calculator"}}]
+        loaded_engine._format_prompt_with_chat_template("What is 2+2?", tools=tools)
+
+        _, kwargs = loaded_engine.tokenizer.apply_chat_template.call_args
+        assert kwargs.get("tools") == tools
+
+    def test_no_tools_means_no_tools_kwarg(self, loaded_engine):
+        loaded_engine._format_prompt_with_chat_template("Hello")
+        _, kwargs = loaded_engine.tokenizer.apply_chat_template.call_args
+        assert "tools" not in kwargs
+
+    def test_template_without_tools_support_falls_back(self, loaded_engine):
+        # A template that rejects the tools= kwarg must not crash — it retries
+        # without tools rather than dropping to the raw prompt.
+        def _fake_template(messages, **kwargs):
+            if "tools" in kwargs:
+                raise TypeError("apply_chat_template() got unexpected kwarg 'tools'")
+            return "<|im_start|>user\nHi<|im_end|>"
+
+        loaded_engine.tokenizer.apply_chat_template.side_effect = _fake_template
+        out = loaded_engine._format_prompt_with_chat_template(
+            "Hi", tools=[{"type": "function", "function": {"name": "x"}}]
+        )
+        assert out == "<|im_start|>user\nHi<|im_end|>"

--- a/tests/unit/test_tool_calling.py
+++ b/tests/unit/test_tool_calling.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from effgen.core.tool_calling import HybridStrategy
+from effgen.core.tool_calling import HybridStrategy, NativeFunctionCallingStrategy
 
 
 def test_hybrid_does_not_treat_thought_only_text_as_final_answer():
@@ -14,3 +14,50 @@ def test_hybrid_does_not_treat_thought_only_text_as_final_answer():
     assert result.final_answer is None
     assert result.is_tool_call is False
     assert result.thought
+
+
+# --- Gemma 4 channel / tool_call format -------------------------------------
+
+def test_gemma_tool_call_parsed_and_name_resolved():
+    """<|tool_call>call:NAME{...} fires, and an invented name maps to a real tool."""
+    strategy = NativeFunctionCallingStrategy()
+    tools = {t: object() for t in ["web_search", "arxiv", "wikipedia"]}
+    text = (
+        "reasoning...<channel|><|tool_call>"
+        'call:search_arxiv{query: "LLM agents"}<tool_call|>'
+    )
+    result = strategy.parse_response(text, tools)
+
+    assert result.is_tool_call is True
+    assert result.tool_name == "arxiv"  # search_arxiv → arxiv
+    assert result.arguments == {"query": "LLM agents"}
+
+
+def test_gemma_final_answer_after_channel_close():
+    """Reasoning in <|channel>...<channel|> is stripped; the answer survives."""
+    strategy = NativeFunctionCallingStrategy()
+    text = "<|channel>thought\nenglish planning\n<channel|>富士山の標高は3,776mです。"
+    result = strategy.parse_response(text)
+
+    assert result.is_tool_call is False
+    assert result.final_answer == "富士山の標高は3,776mです。"
+    assert result.thought  # reasoning captured, not leaked into the answer
+
+
+def test_gemma_truncated_reasoning_yields_no_leaked_answer():
+    """An unclosed channel (max_tokens cut) must not surface raw reasoning."""
+    strategy = NativeFunctionCallingStrategy()
+    result = strategy.parse_response("<|channel>thought\ncut off before finishing")
+
+    assert result.is_tool_call is False
+    assert result.final_answer is None
+
+
+def test_gemma_exact_tool_name_preserved():
+    strategy = NativeFunctionCallingStrategy()
+    tools = {"arxiv": object()}
+    result = strategy.parse_response(
+        '<|tool_call>call:arxiv{"query": "x"}<tool_call|>', tools
+    )
+    assert result.tool_name == "arxiv"
+    assert result.arguments == {"query": "x"}


### PR DESCRIPTION
# Summary
Local MLX agents silently failed to use tools — a "calculator agent" did
(sometimes wrong) mental math with `Tool calls: 0`, and the research preset
fabricated arXiv IDs instead of searching. Root cause: the MLX engine dropped
the tool schemas the agent passes, so instruct models never saw the tools.
This PR makes local MLX tool-calling work and adds Gemma 4 support.

## Changes
- **fix(mlx):** forward tool definitions to `apply_chat_template(tools=...)`
  in `generate()`/`generate_stream()` (with a TypeError fallback for templates
  without a `tools=` kwarg). Also adopt the modern `mlx_lm` sampler API
  (`make_sampler` + logits processors) so generation works on mlx_lm ≥ ~0.20
  (fixes `generate_step() got an unexpected keyword argument 'temp'`).
- **feat(tool-calling):** parse Gemma 4's asymmetric channel format
  (`<|channel>…<channel|>` reasoning, `<|tool_call>call:NAME{…}<tool_call|>`),
  tolerate loose-JSON args, map verb-prefixed names (`search_arxiv`→`arxiv`),
  and strip the channel markers in `sanitize_final_answer` on every path.

Both are guarded by their markers, so non-MLX / non-Gemma models are unaffected.

## Verification
- Qwen2.5-7B (MLX): `247 * 83` now fires the calculator → **20501** (was 20541
  from mental math); research preset calls arxiv and returns real paper IDs.
- 86 unit tests pass (12 new regression tests across mlx_engine, tool_calling,
  answer_sanitization).